### PR TITLE
release: 0.1.0-alpha.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ typechain
 typechain-types
 
 # Hardhat files
+build
 cache
 artifacts
 

--- a/contracts/L2ForwarderFactory.sol
+++ b/contracts/L2ForwarderFactory.sol
@@ -31,7 +31,8 @@ contract L2ForwarderFactory is L2ForwarderPredictor {
     /// @notice Creates an L2Forwarder for the given parameters.
     /// @param  params Parameters for the L2Forwarder
     function createL2Forwarder(L2ForwarderParams memory params) public returns (L2Forwarder) {
-        L2Forwarder l2Forwarder = L2Forwarder(payable(Clones.cloneDeterministic(l2ForwarderImplementation, _salt(params))));
+        L2Forwarder l2Forwarder =
+            L2Forwarder(payable(Clones.cloneDeterministic(l2ForwarderImplementation, _salt(params))));
         l2Forwarder.initialize(params.owner);
 
         emit CreatedL2Forwarder(address(l2Forwarder), params.owner, params);

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -1,6 +1,9 @@
 // we have a hardhat config so that the sdk can build and deploy our contracts
 
 module.exports = {
+  paths: {
+    artifacts: 'build/contracts',
+  },
   solidity: {
     version: "0.8.13",
     settings: {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "hardhat": "^2.18.0"
   },
   "dependencies": {
-    "@arbitrum/token-bridge-contracts": "1.1.0"
+    "@arbitrum/token-bridge-contracts": "1.1.1"
   },
   "scripts": {
     "prepublishOnly": "hardhat clean && hardhat compile",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "files": [
     "hardhat.config.js",
     "contracts/",
-    "build/contracts/src"
+    "build/contracts/contracts"
   ],
   "private": false,
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,16 +1,28 @@
 {
-  "name": "l1-l3-teleport-contracts",
-  "version": "0.1.0",
-  "private": false,
+  "name": "@offchainlabs/l1-l3-teleport-contracts",
+  "version": "0.1.0-alpha.0",
   "license": "Apache-2.0",
+  "description": "Contracts enabling direct ERC20 bridging from L1 to L3",
+  "author": "Offchain Labs, Inc.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/OffchainLabs/l1-l3-teleport-contracts.git"
+  },
+  "files": [
+    "hardhat.config.js",
+    "contracts/",
+    "build/contracts/src"
+  ],
+  "private": false,
   "devDependencies": {
     "hardhat": "^2.18.0"
   },
   "dependencies": {
     "@arbitrum/token-bridge-contracts": "1.1.0"
   },
-  "files": [
-    "hardhat.config.js",
-    "contracts/"
-  ]
+  "scripts": {
+    "prepublishOnly": "hardhat clean && hardhat compile",
+    "build": "hardhat compile",
+    "format": "forge fmt"
+  }
 }

--- a/test/Teleporter.t.sol
+++ b/test/Teleporter.t.sol
@@ -162,7 +162,8 @@ contract L1TeleporterTest is ForkTest {
         returns (L1Teleporter.RetryableGasParams memory, L1Teleporter.RetryableGasCosts memory)
     {
         L1Teleporter.RetryableGasParams memory params = _defaultParams();
-        L1Teleporter.RetryableGasCosts memory costs = teleporter.calculateRetryableGasCosts(l1l2Router.inbox(), 0, params);
+        L1Teleporter.RetryableGasCosts memory costs =
+            teleporter.calculateRetryableGasCosts(l1l2Router.inbox(), 0, params);
         return (params, costs);
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -18,10 +18,10 @@
   optionalDependencies:
     sol2uml "2.2.0"
 
-"@arbitrum/token-bridge-contracts@1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@arbitrum/token-bridge-contracts/-/token-bridge-contracts-1.1.0.tgz#59edd3d864737cf15f331597cac3498c8a7ceeb8"
-  integrity sha512-UEXF5FT2Rus37X4uKBJkaloVITjz/BOeoF/FDpP2hgR0Q3gIgaDenhwY+hKX8donU24X1OacSFW5cFJlpKK6rg==
+"@arbitrum/token-bridge-contracts@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@arbitrum/token-bridge-contracts/-/token-bridge-contracts-1.1.1.tgz#716af9d3a50f544b9ce4e49dfa55058d1715b728"
+  integrity sha512-4gvzydeNBIGlMHFLvO/+r8SdtKglZLKOo6bh8a+nK3pjovKUfBs4ZcpqYNkbabKWeJ9cZCOvw74VX+kJGn65xQ==
   dependencies:
     "@arbitrum/nitro-contracts" "^1.0.0-beta.8"
     "@offchainlabs/upgrade-executor" "1.1.0-beta.0"


### PR DESCRIPTION
The hardhat artifact build path is changed to `build/contracts` to align with other packages. Also note that in recent releases of nitro-contracts and token-bridge-contracts, we no-longer release the hardhat-config but instead only release the source code and build artifacts. We expect the consumer (e.g. sdk) to either use the abi in the artifact directly or supplies [its own build config](https://github.com/OffchainLabs/arbitrum-sdk/pull/295/files) for their type system of choice.