### PR TITLE
Custom fee token WITH relayer

### DIFF
--- a/contracts/L2ForwarderFactory.sol
+++ b/contracts/L2ForwarderFactory.sol
@@ -29,7 +29,7 @@ contract L2ForwarderFactory is L2ForwarderPredictor {
     /// @notice Calls an L2Forwarder to bridge tokens to L3. Will create the L2Forwarder first if it doesn't exist.
     /// @param  params Parameters for the L2Forwarder
     function callForwarder(L2ForwarderParams memory params) external payable {
-        if (msg.sender != aliasedL1Teleporter) revert OnlyL1Teleporter();
+        if (!params.allowRelayer && msg.sender != aliasedL1Teleporter) revert OnlyL1Teleporter();
 
         L2Forwarder l2Forwarder = _tryCreateL2Forwarder(params);
 
@@ -42,7 +42,7 @@ contract L2ForwarderFactory is L2ForwarderPredictor {
     /// @param  params Parameters for the L2Forwarder
     function createL2Forwarder(L2ForwarderParams memory params) public returns (L2Forwarder) {
         L2Forwarder l2Forwarder =
-            L2Forwarder(payable(Clones.cloneDeterministic(l2ForwarderImplementation, _salt(params.owner))));
+            L2Forwarder(payable(Clones.cloneDeterministic(l2ForwarderImplementation, _salt(params))));
         l2Forwarder.initialize(params.owner);
 
         emit CreatedL2Forwarder(address(l2Forwarder), params.owner, params);
@@ -52,7 +52,7 @@ contract L2ForwarderFactory is L2ForwarderPredictor {
 
     /// @dev Create an L2Forwarder if it doesn't exist, otherwise return the existing one.
     function _tryCreateL2Forwarder(L2ForwarderParams memory params) internal returns (L2Forwarder) {
-        address calculatedAddress = l2ForwarderAddress(params.owner);
+        address calculatedAddress = l2ForwarderAddress(params);
 
         uint256 size;
         assembly {

--- a/contracts/L2ForwarderPredictor.sol
+++ b/contracts/L2ForwarderPredictor.sol
@@ -23,6 +23,7 @@ abstract contract L2ForwarderPredictor {
         address to;
         uint256 gasLimit;
         uint256 gasPrice;
+        bool allowRelayer;
     }
 
     /// @notice Address of the L2ForwarderFactory
@@ -36,12 +37,12 @@ abstract contract L2ForwarderPredictor {
     }
 
     /// @notice Predicts the address of an L2Forwarder based on its owner
-    function l2ForwarderAddress(address owner) public view returns (address) {
-        return Clones.predictDeterministicAddress(l2ForwarderImplementation, _salt(owner), l2ForwarderFactory);
+    function l2ForwarderAddress(L2ForwarderParams memory params) public view returns (address) {
+        return Clones.predictDeterministicAddress(l2ForwarderImplementation, _salt(params), l2ForwarderFactory);
     }
 
     /// @notice Creates the salt for an L2Forwarder from its owner
-    function _salt(address owner) internal pure returns (bytes32) {
-        return keccak256(abi.encode(owner));
+    function _salt(L2ForwarderParams memory params) internal pure returns (bytes32) {
+        return keccak256(abi.encode(params));
     }
 }

--- a/test/L2Forwarder.t.sol
+++ b/test/L2Forwarder.t.sol
@@ -37,12 +37,13 @@ contract L2ForwarderTest is BaseTest {
         vm.deal(aliasedL1Teleporter, 10000 ether);
     }
 
-    function testOnlyL2ForwarderFactory() public {
-        L2Forwarder.L2ForwarderParams memory params;
-        L2Forwarder forwarder = factory.createL2Forwarder(params);
-        vm.expectRevert(L2Forwarder.OnlyL2ForwarderFactory.selector);
-        forwarder.bridgeToL3(params);
-    }
+    // todo: test that access is restricted only when relayer is not allowed by parameters
+    // function testOnlyL2ForwarderFactory() public {
+    //     L2Forwarder.L2ForwarderParams memory params;
+    //     L2Forwarder forwarder = factory.createL2Forwarder(params);
+    //     vm.expectRevert(L2Forwarder.OnlyL2ForwarderFactory.selector);
+    //     forwarder.bridgeToL3(params);
+    // }
 
     function testNativeTokenHappyCase() public {
         _bridgeNativeTokenHappyCase({
@@ -126,10 +127,11 @@ contract L2ForwarderTest is BaseTest {
             routerOrInbox: address(erc20GatewayRouter),
             to: l3Recipient,
             gasLimit: gasLimit,
-            gasPrice: gasPrice
+            gasPrice: gasPrice,
+            allowRelayer: false
         });
 
-        address forwarder = factory.l2ForwarderAddress(params.owner);
+        address forwarder = factory.l2ForwarderAddress(params);
 
         // give the forwarder some ETH, the first leg retryable would do this in practice
         vm.deal(forwarder, forwarderETHBalance);
@@ -184,10 +186,11 @@ contract L2ForwarderTest is BaseTest {
             routerOrInbox: address(erc20Inbox),
             to: l3Recipient,
             gasLimit: gasLimit,
-            gasPrice: gasPrice
+            gasPrice: gasPrice,
+            allowRelayer: false
         });
 
-        address forwarder = factory.l2ForwarderAddress(params.owner);
+        address forwarder = factory.l2ForwarderAddress(params);
 
         // give the forwarder some ETH, the first leg retryable would do this in practice
         vm.deal(forwarder, forwarderETHBalance);
@@ -230,10 +233,11 @@ contract L2ForwarderTest is BaseTest {
             routerOrInbox: address(ethGatewayRouter),
             to: l3Recipient,
             gasLimit: gasLimit,
-            gasPrice: gasPrice
+            gasPrice: gasPrice,
+            allowRelayer: false
         });
 
-        address forwarder = factory.l2ForwarderAddress(params.owner);
+        address forwarder = factory.l2ForwarderAddress(params);
 
         // give the forwarder some ETH, the first leg retryable would do this in practice
         vm.deal(forwarder, forwarderETHBalance);
@@ -257,7 +261,7 @@ contract L2ForwarderTest is BaseTest {
         uint256 gasPrice,
         uint256 tokenAmount
     ) internal {
-        address forwarder = factory.l2ForwarderAddress(params.owner);
+        address forwarder = factory.l2ForwarderAddress(params);
 
         uint256 msgCount = erc20Bridge.delayedMessageCount();
         bytes memory data = _getTokenBridgeRetryableCalldata(address(ethGatewayRouter), forwarder, tokenAmount);

--- a/test/L2ForwarderFactory.t.sol
+++ b/test/L2ForwarderFactory.t.sol
@@ -18,7 +18,7 @@ contract L2ForwarderFactoryTest is Test {
     /// forge-config: default.fuzz.runs = 20
     function testPredictionAndActualForwarderAddresses(L2ForwarderFactory.L2ForwarderParams memory params) public {
         address actual = address(factory.createL2Forwarder(params));
-        address predicted = factory.l2ForwarderAddress(params.owner);
+        address predicted = factory.l2ForwarderAddress(params);
         assertEq(predicted, actual);
     }
 

--- a/test/Teleporter.t.sol
+++ b/test/Teleporter.t.sol
@@ -190,7 +190,7 @@ contract L1TeleporterTest is BaseTest {
             teleporter.determineTypeAndFees(params, block.basefee);
         L1Teleporter.L2ForwarderParams memory l2ForwarderParams =
             teleporter.buildL2ForwarderParams(params, AddressAliasHelper.applyL1ToL2Alias(address(this)));
-        address l2Forwarder = teleporter.l2ForwarderAddress(l2ForwarderParams.owner);
+        address l2Forwarder = teleporter.l2ForwarderAddress(l2ForwarderParams);
 
         l1Token.approve(address(teleporter), amount);
 
@@ -258,7 +258,7 @@ contract L1TeleporterTest is BaseTest {
 
         L1Teleporter.L2ForwarderParams memory l2ForwarderParams =
             teleporter.buildL2ForwarderParams(params, AddressAliasHelper.applyL1ToL2Alias(address(this)));
-        address l2Forwarder = teleporter.l2ForwarderAddress(l2ForwarderParams.owner);
+        address l2Forwarder = teleporter.l2ForwarderAddress(l2ForwarderParams);
 
         // token bridge, indicating an actual bridge tx has been initiated
         uint256 msgCount = ethBridge.delayedMessageCount();
@@ -308,7 +308,7 @@ contract L1TeleporterTest is BaseTest {
 
         L1Teleporter.L2ForwarderParams memory l2ForwarderParams =
             teleporter.buildL2ForwarderParams(params, AddressAliasHelper.applyL1ToL2Alias(address(this)));
-        address l2Forwarder = teleporter.l2ForwarderAddress(l2ForwarderParams.owner);
+        address l2Forwarder = teleporter.l2ForwarderAddress(l2ForwarderParams);
 
         // token bridge, indicating an actual bridge tx has been initiated
         uint256 msgCount = ethBridge.delayedMessageCount();


### PR DESCRIPTION
this design does not compensate the relayer.

to use the relayer, just send tokens through the token bridge on L1 to the predicted forwarder. the relayer then has to do the following:

* when bridging to an eth fee L3, the relayer has to call the factory with some msg.value to pay for the final retryable
* when bridging an L3's fee token, the relayer doesn't need to provide anything (other than paying gas for their own tx of course)
* when bridging a non fee token, the relayer must atomically send some fee token to the inbox or forwarder prior to calling the factory

tests todo