### PR TITLE
chore: bump solc to 0.8.23

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ script-deploy-data
 broadcast
 
 hardhat-abigen.js
+lcov.info

--- a/foundry.toml
+++ b/foundry.toml
@@ -4,6 +4,6 @@ out = 'out'
 libs = ['node_modules', 'lib']
 test = 'test'
 cache_path  = 'cache_forge'
-solc_version = '0.8.13'
-optimizer_runs = 200
+solc_version = '0.8.23'
+optimizer_runs = 20000
 fs_permissions = [{ access = "read-write", path = "./script-deploy-data"}]

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -5,11 +5,11 @@ module.exports = {
     artifacts: 'build/contracts',
   },
   solidity: {
-    version: "0.8.13",
+    version: "0.8.23",
     settings: {
       optimizer: {
         enabled: true,
-        runs: 200
+        runs: 20000
       }
     }
   }


### PR DESCRIPTION
Bump to a more recent solc version https://github.com/ethereum/solidity/releases/tag/v0.8.23