### PR TITLE
ci: add audit-ci for npm package security auditing

### DIFF
--- a/.github/workflows/audit-ci.yml
+++ b/.github/workflows/audit-ci.yml
@@ -1,0 +1,33 @@
+name: Audit NPM packages
+
+on:
+  workflow_dispatch:
+  pull_request:
+  merge_group:
+  push:
+    branches:
+      - main
+
+jobs:
+  yarn-audit:
+    name: Audit
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install node_modules
+        uses: OffchainLabs/actions/node-modules/install@main
+        with:
+          cache-key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}-${{ matrix.node-version }}
+
+      - name: Run audit
+        run: yarn audit:ci

--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -1,0 +1,133 @@
+{
+  "$schema": "https://github.com/IBM/audit-ci/raw/main/docs/schema.json",
+  "low": true,
+  "allowlist": [
+    // OpenZeppelin Contracts duplicated Multicall subcalls in v4.9.4; not used in this project
+    "GHSA-699g-q6qh-q4v8",
+    // OpenZeppelin Contracts base64 encoding may read from potentially dirty memory; not used in this project
+    "GHSA-9vx6-7xxf-x967",
+    // OpenZeppelin Contracts governor proposal creation may be blocked by frontrunning
+    "GHSA-5h3x-9wvq-w4m2",
+    // OpenZeppelin Contracts vulnerable to Improper Escaping of Output
+    "GHSA-g4vp-m682-qqmp",
+    // OpenZeppelin Contracts using MerkleProof multiproofs may allow proving arbitrary leaves
+    "GHSA-wprv-93r4-jj2p",
+    // OpenZeppelin GovernorCompatibilityBravo may trim proposal calldata
+    "GHSA-93hq-5wgc-jc82",
+    // OpenZeppelin Contracts TransparentUpgradeableProxy clashing selector calls
+    "GHSA-mx2q-35m2-x2rh",
+    // OpenZeppelin Contracts's SignatureChecker may revert on invalid EIP-1271 signers
+    "GHSA-4g63-c64m-25w9",
+    // OpenZeppelin Contracts vulnerable to ECDSA signature malleability
+    "GHSA-4h98-2769-gh6h",
+    // OpenZeppelin Contracts ERC165Checker unbounded gas consumption
+    "GHSA-7grf-83vw-6f5x",
+    // OpenZeppelin Contracts's ERC165Checker may revert instead of returning false
+    "GHSA-qh9x-gcfh-pcrw",
+    // OpenZeppelin Contracts's GovernorVotesQuorumFraction updates to quorum
+    "GHSA-xrc4-737v-9q75",
+    // Elliptic's private key extraction in ECDSA upon signing malformed input; via hardhat
+    "GHSA-vjh7-7g9h-fjfh",
+    // Elliptic Uses a Cryptographic Primitive with a Risky Implementation; via hardhat
+    "GHSA-848j-6mx2-7j84",
+    // pbkdf2 returns predictable uninitialized/zero-filled memory; via hardhat (dev dep)
+    "GHSA-h7cp-r72f-jxh6",
+    // pbkdf2 silently disregards Uint8Array input; via hardhat (dev dep)
+    "GHSA-v62p-rq8g-8h59",
+    // sha.js missing type checks leading to hash rewind; via hardhat (dev dep)
+    "GHSA-95m3-7q98-8xr5",
+    // cipher-base missing type checks leading to hash rewind; via hardhat (dev dep)
+    "GHSA-cpq7-6gpm-g9rc",
+    // form-data uses unsafe random function; via sol2uml>axios>form-data
+    "GHSA-fjxv-7rqg-78g4",
+    // ws affected by DoS when handling request with many HTTP headers; via hardhat (dev dep)
+    "GHSA-3h5v-q93c-6h6q",
+    // minimatch ReDoS via repeated wildcards; via hardhat (dev dep)
+    "GHSA-3ppc-4f35-3m26",
+    // minimatch ReDoS via multiple non-adjacent GLOBSTAR segments; via hardhat (dev dep)
+    "GHSA-7r86-cg39-jmmj",
+    // minimatch ReDoS via nested extglobs; via hardhat (dev dep)
+    "GHSA-23c5-xmqv-rm74",
+    // serialize-javascript Vulnerable to RCE; via hardhat>mocha (dev dep)
+    "GHSA-5c6j-r48x-rmvq",
+    // Undici Unbounded Memory Consumption in WebSocket; via hardhat (dev dep)
+    "GHSA-vrm6-8vpv-qv8q",
+    // Undici Unhandled Exception in WebSocket Client; via hardhat (dev dep)
+    "GHSA-v9p9-hfj2-hcw8",
+    // tar-fs symlink validation bypass; via sol2uml>puppeteer
+    "GHSA-vj76-c3g6-qr5v",
+    // tar-fs can extract outside specified dir; via sol2uml>puppeteer
+    "GHSA-8cj5-5rvv-wf4v",
+    // tar-fs Link Following and Path Traversal; via sol2uml>puppeteer
+    "GHSA-pq67-2wwv-3xjx",
+    // axios Cross-Site Request Forgery; via sol2uml>axios
+    "GHSA-wf5p-g6vw-rhxx",
+    // axios Requests Vulnerable to SSRF and Credential Leakage; via sol2uml>axios
+    "GHSA-jr5f-v2jv-69x6",
+    // axios Vulnerable to DoS via __proto__ Key in mergeConfig; via sol2uml>axios
+    "GHSA-43fc-jf86-j433",
+    // cookie accepts out of bounds characters; via hardhat (dev dep)
+    "GHSA-pxg6-pf52-xh8x",
+    // tmp allows arbitrary temporary file/directory write via symlink; via hardhat (dev dep)
+    "GHSA-52f5-9888-hmc6",
+    // Undici unbounded decompression chain; via hardhat (dev dep)
+    "GHSA-g9mf-h72j-4rw9",
+    // Undici HTTP Request/Response Smuggling; via hardhat (dev dep)
+    "GHSA-2mjp-6q6p-2qxm",
+    // Undici CRLF Injection via upgrade option; via hardhat (dev dep)
+    "GHSA-4992-7rv2-5pvq",
+    // brace-expansion zero-step sequence causes hang; via hardhat (dev dep)
+    "GHSA-f886-m6hf-6m8v",
+    // jsdiff has a Denial of Service vulnerability in parsePatch and applyPatch; via hardhat>mocha (dev dep)
+    "GHSA-73rr-hh4g-fpgx",
+    // bn.js infinite loop; via hardhat (dev dep)
+    "GHSA-378v-28hj-76wf",
+    // Lodash Prototype Pollution in _.unset and _.omit; via hardhat (dev dep)
+    "GHSA-xxjr-mmjv-4gpg",
+    // micromatch ReDoS; via nitro-contracts>patch-package
+    "GHSA-952p-6rrq-rcjv",
+    // yaml Stack Overflow via deeply nested collections; via nitro-contracts>patch-package
+    "GHSA-48c2-rrv3-qjmp",
+    // follow-redirects Proxy-Authorization header kept across hosts; via hardhat>solc
+    "GHSA-cxjh-pqwp-8mfp",
+    // follow-redirects improperly handles URLs in url.parse(); via hardhat>solc
+    "GHSA-jchw-25xp-jwwc",
+    // serialize-javascript CPU Exhaustion DoS; via hardhat>mocha (dev dep)
+    "GHSA-qj8w-gfj5-8c6v",
+    // nanoid predictable results with non-integer values; via hardhat>mocha (dev dep)
+    "GHSA-mwcw-c2x4-8c55",
+    // js-yaml prototype pollution in merge; via hardhat>mocha (dev dep)
+    "GHSA-mh29-5h37-fv8m",
+    // picomatch Method Injection in POSIX Character Classes; via hardhat (dev dep)
+    "GHSA-3v7f-55p6-f55p",
+    // Undici request smuggling via line feeds; via hardhat (dev dep)
+    "GHSA-c76h-2ccp-4975",
+    // Undici Fetch API request smuggling; via hardhat (dev dep)
+    "GHSA-wf6x-7x77-mvgw",
+    // semver ReDoS; via hardhat (dev dep)
+    "GHSA-c2c7-rcm5-vvqj",
+    // undici request smuggling in pipeline; via hardhat (dev dep)
+    "GHSA-3787-6prv-h9w3",
+    // undici cookie leak on cross-origin redirect; via hardhat (dev dep)
+    "GHSA-xq7p-g2vc-g82p",
+    // undici request smuggling via content-type / content-length; via hardhat (dev dep)
+    "GHSA-m4v8-wqvr-p9f7",
+    // undici vulnerable to CRLF injection; via hardhat (dev dep)
+    "GHSA-f7q4-pwc6-w24p",
+    // json5 Prototype Pollution via parse method; via hardhat (dev dep)
+    "GHSA-9qxr-qj54-h672",
+    // cross-spawn shell injection on Windows; via hardhat (dev dep)
+    "GHSA-3xgq-45jj-v275",
+    // Chromium/Puppeteer vulnerabilities; via sol2uml>puppeteer
+    "GHSA-584q-6j8j-r5pm",
+    "GHSA-434g-2637-qmqr",
+    "GHSA-cxrh-j4jr-qwg3",
+    "GHSA-49q7-c7j4-3p7m",
+    "GHSA-76p7-773f-r4q5",
+    "GHSA-977x-g7h5-7qgw",
+    "GHSA-fc9h-whq2-v747",
+    "GHSA-grv7-fg5c-xmjg",
+    "GHSA-p6mc-m468-83gw",
+    "GHSA-v6h2-p8h4-qcjw"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   ],
   "private": false,
   "devDependencies": {
+    "audit-ci": "^6.6.1",
     "hardhat": "^2.18.0"
   },
   "dependencies": {
@@ -24,6 +25,7 @@
   "scripts": {
     "prepublishOnly": "hardhat clean && hardhat compile",
     "build": "hardhat compile",
+    "audit:ci": "audit-ci --config ./audit-ci.jsonc",
     "format": "forge fmt"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -849,6 +849,14 @@
   resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
   integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
 
+JSONStream@^1.3.5:
+  version "1.3.5"
+  resolved "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz#3208c1f08d3a4d99261ab64f92302bc15e111ca0"
+  integrity sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==
+  dependencies:
+    jsonparse "^1.2.0"
+    through ">=2.2.7 <3"
+
 abstract-level@^1.0.0, abstract-level@^1.0.2, abstract-level@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/abstract-level/-/abstract-level-1.0.3.tgz#78a67d3d84da55ee15201486ab44c09560070741"
@@ -982,6 +990,20 @@ at-least-node@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
   integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
+
+audit-ci@^6.6.1:
+  version "6.6.1"
+  resolved "https://registry.npmjs.org/audit-ci/-/audit-ci-6.6.1.tgz#7c53808f6f94adbe60baf1d7c24f53c626619453"
+  integrity sha512-zqZEoYfEC4QwX5yBkDNa0h7YhZC63HWtKtP19BVq+RS0dxRBInfmHogxe4VUeOzoADQjuTLZUI7zp3Pjyl+a5g==
+  dependencies:
+    JSONStream "^1.3.5"
+    cross-spawn "^7.0.3"
+    escape-string-regexp "^4.0.0"
+    event-stream "4.0.1"
+    jju "^1.4.0"
+    readline-transform "1.0.0"
+    semver "^7.0.0"
+    yargs "^17.0.0"
 
 available-typed-arrays@^1.0.5:
   version "1.0.5"
@@ -1294,6 +1316,15 @@ cliui@^7.0.2:
     strip-ansi "^6.0.0"
     wrap-ansi "^7.0.0"
 
+cliui@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz#0c04b075db02cbfe60dc8e6cf2f5486b1a3608aa"
+  integrity sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.1"
+    wrap-ansi "^7.0.0"
+
 color-convert@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
@@ -1425,6 +1456,15 @@ cross-spawn@^6.0.5:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
+cross-spawn@^7.0.3:
+  version "7.0.6"
+  resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
+  integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
+  dependencies:
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
+
 css-select@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/css-select/-/css-select-5.1.0.tgz#b8ebd6554c3637ccc76688804ad3f6a6fdaea8a6"
@@ -1520,6 +1560,11 @@ domutils@^3.0.1:
     dom-serializer "^2.0.0"
     domelementtype "^2.3.0"
     domhandler "^5.0.3"
+
+duplexer@^0.1.1, duplexer@~0.1.1:
+  version "0.1.2"
+  resolved "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz#3abe43aef3835f8ae077d136ddce0f276b0400e6"
+  integrity sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==
 
 elliptic@6.5.4, elliptic@^6.5.2, elliptic@^6.5.4:
   version "6.5.4"
@@ -1639,7 +1684,7 @@ escalade@^3.1.1:
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
   integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
 
-escape-string-regexp@4.0.0:
+escape-string-regexp@4.0.0, escape-string-regexp@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
@@ -1756,6 +1801,19 @@ ethjs-util@0.1.6, ethjs-util@^0.1.6:
     is-hex-prefixed "1.0.0"
     strip-hex-prefix "1.0.0"
 
+event-stream@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.npmjs.org/event-stream/-/event-stream-4.0.1.tgz#4092808ec995d0dd75ea4580c1df6a74db2cde65"
+  integrity sha512-qACXdu/9VHPBzcyhdOWR5/IahhGMf0roTeZJfzz077GwylcDd90yOHLouhmv7GJ5XzPi6ekaQWd8AvPP2nOvpA==
+  dependencies:
+    duplexer "^0.1.1"
+    from "^0.1.7"
+    map-stream "0.0.7"
+    pause-stream "^0.0.11"
+    split "^1.0.1"
+    stream-combiner "^0.2.2"
+    through "^2.3.8"
+
 evp_bytestokey@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz#7fcbdb198dc71959432efe13842684e0525acb02"
@@ -1859,6 +1917,11 @@ fp-ts@^1.0.0:
   version "1.19.5"
   resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-1.19.5.tgz#3da865e585dfa1fdfd51785417357ac50afc520a"
   integrity sha512-wDNqTimnzs8QqpldiId9OavWK2NptormjXnRJTQecNjzwfyp6P/8s/zG8e4h3ja3oqkKaY72UlTjQYt/1yXf9A==
+
+from@^0.1.7:
+  version "0.1.7"
+  resolved "https://registry.npmjs.org/from/-/from-0.1.7.tgz#83c60afc58b9c56997007ed1a768b3ab303a44fe"
+  integrity sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==
 
 fs-constants@^1.0.0:
   version "1.0.0"
@@ -2406,6 +2469,11 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
 
+jju@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz#a3abe2718af241a2b2904f84a625970f389ae32a"
+  integrity sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==
+
 js-graph-algorithms@^1.0.18:
   version "1.0.18"
   resolved "https://registry.yarnpkg.com/js-graph-algorithms/-/js-graph-algorithms-1.0.18.tgz#f96ec87bf194f5c0a31365fa0e1d07b7b962d891"
@@ -2450,6 +2518,11 @@ jsonfile@^6.0.1:
     universalify "^2.0.0"
   optionalDependencies:
     graceful-fs "^4.1.6"
+
+jsonparse@^1.2.0:
+  version "1.3.1"
+  resolved "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
+  integrity sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==
 
 keccak@^3.0.0, keccak@^3.0.2:
   version "3.0.4"
@@ -2556,6 +2629,11 @@ lru_map@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/lru_map/-/lru_map-0.3.3.tgz#b5c8351b9464cbd750335a79650a0ec0e56118dd"
   integrity sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ==
+
+map-stream@0.0.7:
+  version "0.0.7"
+  resolved "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz#8a1f07896d82b10926bd3744a2420009f88974a8"
+  integrity sha512-C0X0KQmGm3N2ftbTGBhSyuydQ+vV1LC3f3zPvT3RXHXNZrvfPZcoXp/N5DOa8vedX/rTMm2CjTtivFg2STJMRQ==
 
 mcl-wasm@^0.7.1:
   version "0.7.9"
@@ -2903,10 +2981,22 @@ path-key@^2.0.1:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
   integrity sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==
 
+path-key@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
+  integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
+
 path-parse@^1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
+
+pause-stream@^0.0.11:
+  version "0.0.11"
+  resolved "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz#fe5a34b0cbce12b5aa6a2b403ee2e73b602f1445"
+  integrity sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==
+  dependencies:
+    through "~2.3"
 
 pbkdf2@^3.0.17:
   version "3.1.2"
@@ -3023,6 +3113,11 @@ readdirp@~3.6.0:
   integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
   dependencies:
     picomatch "^2.2.1"
+
+readline-transform@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/readline-transform/-/readline-transform-1.0.0.tgz#3157f97428acaec0f05a5c1ff2c3120f4e6d904b"
+  integrity sha512-7KA6+N9IGat52d83dvxnApAWN+MtVb1MiVuMR/cf1O4kYsJG+g/Aav0AHcHKsb6StinayfPLne0+fMX2sOzAKg==
 
 regexp.prototype.flags@^1.5.1:
   version "1.5.1"
@@ -3154,6 +3249,11 @@ semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
+semver@^7.0.0:
+  version "7.7.4"
+  resolved "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz#28464e36060e991fa7a11d0279d2d3f3b57a7e8a"
+  integrity sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==
+
 serialize-javascript@6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.0.tgz#efae5d88f45d7924141da8b5c3a7a7e663fefeb8"
@@ -3205,10 +3305,22 @@ shebang-command@^1.2.0:
   dependencies:
     shebang-regex "^1.0.0"
 
+shebang-command@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
+  integrity sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
+  dependencies:
+    shebang-regex "^3.0.0"
+
 shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
   integrity sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==
+
+shebang-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
+  integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
 side-channel@^1.0.4:
   version "1.0.4"
@@ -3279,6 +3391,13 @@ source-map@^0.6.0:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
+split@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/split/-/split-1.0.1.tgz#605bd9be303aa59fb35f9229fbea0ddec9ea07d9"
+  integrity sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==
+  dependencies:
+    through "2"
+
 stacktrace-parser@^0.1.10:
   version "0.1.10"
   resolved "https://registry.yarnpkg.com/stacktrace-parser/-/stacktrace-parser-0.1.10.tgz#29fb0cae4e0d0b85155879402857a1639eb6051a"
@@ -3291,7 +3410,15 @@ statuses@2.0.1:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.1.tgz#55cb000ccf1d48728bd23c685a063998cf1a1b63"
   integrity sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==
 
-string-width@^4.1.0, string-width@^4.2.0:
+stream-combiner@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz#aec8cbac177b56b6f4fa479ced8c1912cee52858"
+  integrity sha512-6yHMqgLYDzQDcAkL+tjJDC5nSNuNIx0vZtRZeiPh7Saef7VHX9H5Ijn9l2VIol2zaNYlYEX6KyuT/237A58qEQ==
+  dependencies:
+    duplexer "~0.1.1"
+    through "~2.3.4"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -3395,7 +3522,7 @@ tar-stream@^2.1.4:
     inherits "^2.0.3"
     readable-stream "^3.1.1"
 
-through@^2.3.8:
+through@2, "through@>=2.2.7 <3", through@^2.3.8, through@~2.3, through@~2.3.4:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==
@@ -3597,6 +3724,13 @@ which@^1.2.9:
   dependencies:
     isexe "^2.0.0"
 
+which@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.npmjs.org/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
+  integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
+  dependencies:
+    isexe "^2.0.0"
+
 workerpool@6.2.1:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
@@ -3656,6 +3790,11 @@ yargs-parser@^20.2.2:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
   integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
 
+yargs-parser@^21.1.1:
+  version "21.1.1"
+  resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
+  integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
+
 yargs-unparser@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/yargs-unparser/-/yargs-unparser-2.0.0.tgz#f131f9226911ae5d9ad38c432fe809366c2325eb"
@@ -3678,6 +3817,19 @@ yargs@16.2.0:
     string-width "^4.2.0"
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
+
+yargs@^17.0.0:
+  version "17.7.2"
+  resolved "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
+  integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
+  dependencies:
+    cliui "^8.0.1"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.1.1"
 
 yauzl@^2.10.0:
   version "2.10.0"


### PR DESCRIPTION
## Summary
- Adds `audit-ci` (^6.6.1) to match the setup in `nitro-contracts` and `token-bridge-contracts`
- Adds `audit-ci.jsonc` config with `"low": true` and allowlisted advisories (all transitive through `hardhat`, `@arbitrum/nitro-contracts`, or `@arbitrum/token-bridge-contracts` — none affect this project's contracts)
- Adds `.github/workflows/audit-ci.yml` GitHub Actions workflow (Node 18, triggers on PR/push to main/merge_group/workflow_dispatch)
- Adds `audit:ci` script to `package.json`

## Test plan
- [x] `yarn audit:ci` passes locally