### PR TITLE
style: fix forge fmt for nightly compatibility

### DIFF
--- a/contracts/L1Teleporter.sol
+++ b/contracts/L1Teleporter.sol
@@ -5,8 +5,9 @@ import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol
 import {Pausable} from "@openzeppelin/contracts/security/Pausable.sol";
 import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
 import {AddressAliasHelper} from "@arbitrum/nitro-contracts/src/libraries/AddressAliasHelper.sol";
-import {L1GatewayRouter} from
-    "@arbitrum/token-bridge-contracts/contracts/tokenbridge/ethereum/gateway/L1GatewayRouter.sol";
+import {
+    L1GatewayRouter
+} from "@arbitrum/token-bridge-contracts/contracts/tokenbridge/ethereum/gateway/L1GatewayRouter.sol";
 import {IInbox} from "@arbitrum/nitro-contracts/src/bridge/IInbox.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {L2ForwarderPredictor} from "./L2ForwarderPredictor.sol";
@@ -245,11 +246,11 @@ contract L1Teleporter is Pausable, AccessControl, L2ForwarderPredictor, IL1Telep
     function _requireZeroFeeTokenIfSkipping(TeleportParams calldata params) internal pure {
         if (
             params.l3FeeTokenL1Addr == SKIP_FEE_TOKEN_MAGIC_ADDRESS
-                && (
-                    params.gasParams.l2l3TokenBridgeMaxSubmissionCost > 0 || params.gasParams.l2l3TokenBridgeGasLimit > 0
-                        || params.gasParams.l1l2FeeTokenBridgeGasLimit > 0
-                        || params.gasParams.l1l2FeeTokenBridgeMaxSubmissionCost > 0 || params.gasParams.l3GasPriceBid > 0
-                )
+                && (params.gasParams.l2l3TokenBridgeMaxSubmissionCost > 0
+                    || params.gasParams.l2l3TokenBridgeGasLimit > 0
+                    || params.gasParams.l1l2FeeTokenBridgeGasLimit > 0
+                    || params.gasParams.l1l2FeeTokenBridgeMaxSubmissionCost > 0
+                    || params.gasParams.l3GasPriceBid > 0)
         ) {
             revert NonZeroFeeTokenAmount();
         }

--- a/contracts/L2Forwarder.sol
+++ b/contracts/L2Forwarder.sol
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.13;
 
-import {L1GatewayRouter} from
-    "@arbitrum/token-bridge-contracts/contracts/tokenbridge/ethereum/gateway/L1GatewayRouter.sol";
+import {
+    L1GatewayRouter
+} from "@arbitrum/token-bridge-contracts/contracts/tokenbridge/ethereum/gateway/L1GatewayRouter.sol";
 import {IERC20Inbox} from "@arbitrum/nitro-contracts/src/bridge/IERC20Inbox.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
@@ -99,7 +100,8 @@ contract L2Forwarder is IL2Forwarder {
         uint256 maxSubmissionCost = IERC20Inbox(params.routerOrInbox).calculateRetryableSubmissionFee(0, 0);
         uint256 totalFeeAmount = maxSubmissionCost + (params.gasLimit * params.gasPriceBid);
         uint256 callValue = tokenBalance - totalFeeAmount;
-        IERC20Inbox(params.routerOrInbox).createRetryableTicket({
+        IERC20Inbox(params.routerOrInbox)
+            .createRetryableTicket({
             to: params.to,
             l2CallValue: callValue,
             maxSubmissionCost: maxSubmissionCost,
@@ -130,15 +132,16 @@ contract L2Forwarder is IL2Forwarder {
 
         // send tokens through the bridge to intended recipient
         // use user supplied max submission fee instead of sending all the fee token balance
-        L1GatewayRouter(params.routerOrInbox).outboundTransferCustomRefund(
-            params.l2Token,
-            params.to,
-            params.to,
-            tokenBalance,
-            params.gasLimit,
-            params.gasPriceBid,
-            abi.encode(params.maxSubmissionCost, bytes(""), totalFeeAmount)
-        );
+        L1GatewayRouter(params.routerOrInbox)
+            .outboundTransferCustomRefund(
+                params.l2Token,
+                params.to,
+                params.to,
+                tokenBalance,
+                params.gasLimit,
+                params.gasPriceBid,
+                abi.encode(params.maxSubmissionCost, bytes(""), totalFeeAmount)
+            );
 
         emit BridgedToL3(tokenBalance, totalFeeAmount);
     }

--- a/contracts/L2ForwarderFactory.sol
+++ b/contracts/L2ForwarderFactory.sol
@@ -28,8 +28,9 @@ contract L2ForwarderFactory is L2ForwarderPredictor, IL2ForwarderFactory {
 
     /// @inheritdoc IL2ForwarderFactory
     function createL2Forwarder(address owner, address routerOrInbox, address to) public returns (IL2Forwarder) {
-        IL2Forwarder l2Forwarder =
-            IL2Forwarder(payable(Clones.cloneDeterministic(l2ForwarderImplementation, _salt(owner, routerOrInbox, to))));
+        IL2Forwarder l2Forwarder = IL2Forwarder(
+            payable(Clones.cloneDeterministic(l2ForwarderImplementation, _salt(owner, routerOrInbox, to)))
+        );
 
         l2Forwarder.initialize(owner);
 

--- a/contracts/lib/TeleportationType.sol
+++ b/contracts/lib/TeleportationType.sol
@@ -5,7 +5,6 @@ enum TeleportationType {
     Standard, // Teleporting a token to an ETH fee L3
     OnlyCustomFee, // Teleporting a L3's custom fee token to a custom (non-eth) fee L3
     NonFeeTokenToCustomFee // Teleporting a non-fee token to a custom (non-eth) fee L3
-
 }
 
 error InvalidTeleportation();

--- a/test/Base.t.sol
+++ b/test/Base.t.sol
@@ -4,17 +4,22 @@ pragma solidity ^0.8.13;
 import {Test, console2} from "forge-std/Test.sol";
 import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
-import {L1GatewayRouter} from
-    "@arbitrum/token-bridge-contracts/contracts/tokenbridge/ethereum/gateway/L1GatewayRouter.sol";
-import {L1ArbitrumGateway} from
-    "@arbitrum/token-bridge-contracts/contracts/tokenbridge/ethereum/gateway/L1ArbitrumGateway.sol";
-import {L1ERC20Gateway} from
-    "@arbitrum/token-bridge-contracts/contracts/tokenbridge/ethereum/gateway/L1ERC20Gateway.sol";
-import {L1OrbitERC20Gateway} from
-    "@arbitrum/token-bridge-contracts/contracts/tokenbridge/ethereum/gateway/L1OrbitERC20Gateway.sol";
+import {
+    L1GatewayRouter
+} from "@arbitrum/token-bridge-contracts/contracts/tokenbridge/ethereum/gateway/L1GatewayRouter.sol";
+import {
+    L1ArbitrumGateway
+} from "@arbitrum/token-bridge-contracts/contracts/tokenbridge/ethereum/gateway/L1ArbitrumGateway.sol";
+import {
+    L1ERC20Gateway
+} from "@arbitrum/token-bridge-contracts/contracts/tokenbridge/ethereum/gateway/L1ERC20Gateway.sol";
+import {
+    L1OrbitERC20Gateway
+} from "@arbitrum/token-bridge-contracts/contracts/tokenbridge/ethereum/gateway/L1OrbitERC20Gateway.sol";
 
-import {L1OrbitGatewayRouter} from
-    "@arbitrum/token-bridge-contracts/contracts/tokenbridge/ethereum/gateway/L1OrbitGatewayRouter.sol";
+import {
+    L1OrbitGatewayRouter
+} from "@arbitrum/token-bridge-contracts/contracts/tokenbridge/ethereum/gateway/L1OrbitGatewayRouter.sol";
 
 import {IBridge, Bridge} from "@arbitrum/nitro-contracts/src/bridge/Bridge.sol";
 import {IInbox, Inbox} from "@arbitrum/nitro-contracts/src/bridge/Inbox.sol";

--- a/test/L2Forwarder.t.sol
+++ b/test/L2Forwarder.t.sol
@@ -7,10 +7,12 @@ import {L2ForwarderFactory} from "../contracts/L2ForwarderFactory.sol";
 import {L2Forwarder} from "../contracts/L2Forwarder.sol";
 import {L2ForwarderPredictor} from "../contracts/L2ForwarderPredictor.sol";
 import {BaseTest} from "./Base.t.sol";
-import {L1ArbitrumGateway} from
-    "@arbitrum/token-bridge-contracts/contracts/tokenbridge/ethereum/gateway/L1ArbitrumGateway.sol";
-import {L1GatewayRouter} from
-    "@arbitrum/token-bridge-contracts/contracts/tokenbridge/ethereum/gateway/L1GatewayRouter.sol";
+import {
+    L1ArbitrumGateway
+} from "@arbitrum/token-bridge-contracts/contracts/tokenbridge/ethereum/gateway/L1ArbitrumGateway.sol";
+import {
+    L1GatewayRouter
+} from "@arbitrum/token-bridge-contracts/contracts/tokenbridge/ethereum/gateway/L1GatewayRouter.sol";
 import {AddressAliasHelper} from "@arbitrum/nitro-contracts/src/libraries/AddressAliasHelper.sol";
 import {IL2Forwarder} from "../contracts/interfaces/IL2Forwarder.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
@@ -438,12 +440,9 @@ contract L2ForwarderTest is BaseTest {
         returns (bytes memory)
     {
         address l1Gateway = L1GatewayRouter(gatewayRouter).getGateway(address(l2Token));
-        bytes memory l1l2TokenBridgeRetryableCalldata = L1ArbitrumGateway(l1Gateway).getOutboundCalldata({
-            _l1Token: address(l2Token),
-            _from: address(l2Forwarder),
-            _to: l3Recipient,
-            _amount: tokenAmount,
-            _data: ""
+        bytes memory l1l2TokenBridgeRetryableCalldata = L1ArbitrumGateway(l1Gateway)
+            .getOutboundCalldata({
+            _l1Token: address(l2Token), _from: address(l2Forwarder), _to: l3Recipient, _amount: tokenAmount, _data: ""
         });
         return l1l2TokenBridgeRetryableCalldata;
     }

--- a/test/Teleporter.t.sol
+++ b/test/Teleporter.t.sol
@@ -9,8 +9,9 @@ import {L2ForwarderFactory} from "../contracts/L2ForwarderFactory.sol";
 import {L2ForwarderPredictor} from "../contracts/L2ForwarderPredictor.sol";
 import {TeleportationType, InvalidTeleportation} from "../contracts/lib/TeleportationType.sol";
 import {AddressAliasHelper} from "@arbitrum/nitro-contracts/src/libraries/AddressAliasHelper.sol";
-import {L1ArbitrumGateway} from
-    "@arbitrum/token-bridge-contracts/contracts/tokenbridge/ethereum/gateway/L1ArbitrumGateway.sol";
+import {
+    L1ArbitrumGateway
+} from "@arbitrum/token-bridge-contracts/contracts/tokenbridge/ethereum/gateway/L1ArbitrumGateway.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {ERC20PresetMinterPauser} from "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetMinterPauser.sol";
 import {BaseTest} from "./Base.t.sol";
@@ -411,11 +412,7 @@ contract L1TeleporterTest is BaseTest {
         // token bridge, indicating an actual bridge tx has been initiated
         uint256 msgCount = ethBridge.delayedMessageCount();
         bytes memory l1l2TokenBridgeRetryableCalldata = ethDefaultGateway.getOutboundCalldata({
-            _token: address(l1Token),
-            _from: address(teleporter),
-            _to: l2Forwarder,
-            _amount: amount,
-            _data: ""
+            _token: address(l1Token), _from: address(teleporter), _to: l2Forwarder, _amount: amount, _data: ""
         });
         _expectTokenBridgeRetryable(msgCount, params, retryableCosts, l2Forwarder, l1l2TokenBridgeRetryableCalldata);
         _expectFactoryRetryable(
@@ -582,11 +579,7 @@ contract L1TeleporterTest is BaseTest {
         // token bridge, indicating an actual bridge tx has been initiated
         uint256 msgCount = ethBridge.delayedMessageCount();
         bytes memory l1l2TokenBridgeRetryableCalldata = ethDefaultGateway.getOutboundCalldata({
-            _token: address(l1Token),
-            _from: address(teleporter),
-            _to: l2Forwarder,
-            _amount: amount,
-            _data: ""
+            _token: address(l1Token), _from: address(teleporter), _to: l2Forwarder, _amount: amount, _data: ""
         });
         _expectTokenBridgeRetryable(msgCount, params, retryableCosts, l2Forwarder, l1l2TokenBridgeRetryableCalldata);
         _expectFactoryRetryable(msgCount + 1, params, retryableCosts, l2ForwarderParams, l2Forwarder, 0);


### PR DESCRIPTION
## Summary
- Runs `forge fmt` with Foundry nightly to match the CI configuration in `build-test.yml`
- Fixes pre-existing format check failures caused by formatting drift between stable and nightly Foundry

## Test plan
- [x] `forge fmt --check` passes with Foundry nightly locally